### PR TITLE
Remove List difference `\\`

### DIFF
--- a/helium-overture.cabal
+++ b/helium-overture.cabal
@@ -1,5 +1,5 @@
 name:                helium-overture
-version:             1.0.0
+version:             1.0.1
 synopsis:            A backwards-compatible, modern replacement for the Prelude.
 license:             PublicDomain
 author:              Patrick Thomson

--- a/src/Overture.hs
+++ b/src/Overture.hs
@@ -45,7 +45,7 @@ import           Data.List                as X hiding (all, and, any, concat,
                                                 foldl', foldl1, foldr, foldr1,
                                                 mapAccumL, mapAccumR, maximum,
                                                 maximumBy, minimum, minimumBy,
-                                                notElem, or, product, sum)
+                                                notElem, or, product, sum, (\\))
 import           Data.Maybe               as X
 import           Data.Monoid              as X
 import           Data.Ord                 as X


### PR DESCRIPTION
Remove the export of List difference (`\\`) from Overture.

List difference only removes the <i>n</i>th instance of a member if the member is also specified _n_ times in the minuend. E.g.

```
λ: [1] \\ [1]
[]

λ: [1,1] \\ [1]
[1]

λ: [1,1] \\ [1,1]
[]
```

I've seen this lead to unintentional bugs, as programmers expect `\\` to act like a _Set_ difference. To help prevent unintended results, don't export `\\` from Overture and let the programmer explicitly import `Data.List.\\` or `Set.List.\\` or whatever tickles their fancy